### PR TITLE
feat: navbar icon

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,4 @@
-$fa-font-path: "@fortawesome/fontawesome-free/webfonts";
+$fa-font-path: "";
 $primary: #a371f7;
 $secondary: #343a40;
 $body-color: #f8f9fa;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
     %header
       %nav.navbar.navbar-dark.bg-dark.border-bottom
         .container-fluid
-          = link_to root_path, class: 'navbar-brand px-3' do
+          = link_to root_path, class: 'navbar-brand px-2' do
             %i.fa-solid.fa-wave-square.text-primary
             WAV3
     %main

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,6 +11,8 @@
     %header
       %nav.navbar.navbar-dark.bg-dark.border-bottom
         .container-fluid
-          = link_to 'WAV3', root_path, class: 'navbar-brand px-3'
+          = link_to root_path, class: 'navbar-brand px-3' do
+            %i.fa-solid.fa-wave-square.text-primary
+            WAV3
     %main
       = yield

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,5 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+Rails.application.config.assets.paths << Rails.root.join('node_modules/@fortawesome/fontawesome-free/webfonts')


### PR DESCRIPTION
Built off #2

Adds a little fontawesome icon to the navbar. I'm thinking we might obviously come up with a fully custom icon eventually, but I figured we could use a placeholder for a _little_ character.

Also, fontawesome was broken (the initializer/`fa-font-path` adjustments fixes it). Forgot what version of rails this was.