### PR TITLE
chore: silence esbuild

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.before :suite do
-    system 'yarn build', out: File::NULL
+    system 'yarn build --log-level=error', out: File::NULL
     system 'yarn build:css', out: File::NULL
   end
 


### PR DESCRIPTION
I've noticed that when running rspec, esbuild still outputs some lines about what it built. This should silence it once and for all.