### PR TITLE
chore: fix application system spec

### DIFF
--- a/spec/system/application_spec.rb
+++ b/spec/system/application_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe 'Application' do
   describe 'visiting the root page' do
     before { visit '/' }


### PR DESCRIPTION
I forgot this when I suggested it - it's needed to be able to run the spec standalone